### PR TITLE
Firefox support (#1)

### DIFF
--- a/Dark-Minimalistic-Scrollbar.user.css
+++ b/Dark-Minimalistic-Scrollbar.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         Dark Minimalistic Scrollbar
 @namespace    https://github.com/pabli24/DMScrollbar
-@version      0.1.3
+@version      0.1.4
 @description  Customizable scrollbar for WebKit based browsers (Chrome, Opera).
 @author       Pabli
 @license      CC-BY-SA-4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
@@ -18,6 +18,7 @@
 @var number width "width (px)" [10,0,null,null,'px']
 @var number b "border (px)" [2,0,null,null,'px']
 @var number br "border-radius (px)" [10,0,null,null,'px']
+@var select scrollbar-width "width (firefox only)" ["auto","thin","none"]
 ==/UserStyle== */
 @-moz-document regexp(".*") {
 html::-webkit-scrollbar {
@@ -45,5 +46,9 @@ html::-webkit-scrollbar-thumb:active {
 }
 html::-webkit-scrollbar-corner {
 	background: /*[[corner]]*/ !important;
+}
+:root {
+	scrollbar-width: /*[[scrollbar-width]]*/ !important;
+	scrollbar-color: /*[[bar]]*/ /*[[bg]]*/ !important;
 }
 }

--- a/Dark-Minimalistic-Scrollbar.user.css
+++ b/Dark-Minimalistic-Scrollbar.user.css
@@ -2,7 +2,7 @@
 @name         Dark Minimalistic Scrollbar
 @namespace    https://github.com/pabli24/DMScrollbar
 @version      0.1.4
-@description  Customizable scrollbar for WebKit based browsers (Chrome, Opera).
+@description  Customizable scrollbar for WebKit based browsers (Chrome, Opera) and not fully customizable for Firefox.
 @author       Pabli
 @license      CC-BY-SA-4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
 @homepageURL  https://github.com/pabli24/DMScrollbar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img align="right" src="./images/dms.gif"><h1 align="center"><i>Dark Minimalistic Scrollbar</i></h1>
 Working on Chrome, Opera and probably in any other WebKit based browsers. You can change colors and sizes for elements of scrollbar.
 
+From version 0.1.4 minimal support for Firefox has been added such as thumb color, track color and scrollbar width.
+
 ## Installation
 * Download Stylus extension: [Chrome](https://chrome.google.com/webstore/detail/clngdbkpkpeebahjckkjfobafhncgmne), [Opera](https://addons.opera.com/extensions/details/stylus/) (better use chrome web store because of newer version of stylus) <br>
 * [![Install directly with Stylus](https://img.shields.io/badge/Install%20directly%20with-Stylus-238b8b.svg)](https://raw.githubusercontent.com/pabli24/DMScrollbar/master/Dark-Minimalistic-Scrollbar.user.css) (or from [userstyles.org](https://userstyles.org/styles/127819/dark-minimalistic-scrollbar))


### PR DESCRIPTION
* Add Firefox support

Adds scrollbar customization for Firefox as per [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color)
Those 2 properties don't break WebKit functionality.

* Bump version